### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SuperOffice Developer Network
 
-Live version of this application: https://devnet-tokens.azurewebsites.net
+Live version of this application: https://devnet-tools.superoffice.com
 
 Getting Started:
 


### PR DESCRIPTION
We have protected the devnet-tokens.azurewebsite.net under our own domain name devnet-tools.superoffice.com now.  By having a reputable domain name it will avoid the risk of being blocked by some firewalls/web filtering or other network security solutions due that this “azurewebsites.net” default domain is used on phishing campaigns.

This is because on its free version there is no way to configure it to a custom domain name (more info here: https://www.malwarebytes.com/blog/news/2014/04/cyber-criminals-interested-in-microsoft-azure-too).